### PR TITLE
fix: with_target args order

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -208,7 +208,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['14', '16', '18']
+        node: ['16', '18']
         settings:
           - host: macos-latest
             target: 'x86_64-apple-darwin'
@@ -238,10 +238,11 @@ jobs:
         if: matrix.settings.host == 'ubuntu-latest'
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y gnome-keyring
+          sudo apt-get install -y gnome-keyring dbus dbus-x11
       - name: Test bindings
         if: matrix.settings.host == 'ubuntu-latest'
-        run: dbus-run-session -- bash -c "echo -n "test" | gnome-keyring-daemon --unlock && yarn test"
+        run: |
+          dbus-run-session -- bash -c "rm -f $HOME/.local/share/keyrings/* && echo -n "test" | gnome-keyring-daemon --unlock && yarn test"
       - name: Test bindings
         if: matrix.settings.host != 'ubuntu-latest'
         run: yarn test

--- a/__test__/index.spec.ts
+++ b/__test__/index.spec.ts
@@ -1,27 +1,76 @@
+import os from 'node:os'
+
 import test from 'ava'
 
 import { Entry, findCredentials, findCredentialsAsync, AsyncEntry } from '../index'
 
+const testPassword = 'napi.rs'
+const testService = 'keyring-node-test-service'
+const testUser = 'test-user'
+
 test('Should create and get password back', (t) => {
-  const password = 'napi.rs'
-  const service = 'gnome-keyring'
-  const entry = new Entry(service, 'napi')
-  t.notThrows(() => entry.setPassword(password))
-  t.is(entry.getPassword(), password)
-  const [{ password: pass, account }] = findCredentials(service)
-  t.is(pass, password)
-  t.is(account, 'napi')
+  const entry = new Entry(testService, testUser)
+  t.notThrows(() => entry.setPassword(testPassword))
+  t.is(entry.getPassword(), testPassword)
+  const [{ password: pass, account }] = findCredentials(testService)
+  t.is(pass, testPassword)
+  t.is(account, testUser)
   t.notThrows(() => entry.deletePassword())
 })
 
 test('Should create and get password back async', async (t) => {
-  const password = 'napi.rs'
-  const service = 'gnome-keyring'
-  const entry = new AsyncEntry(service, 'napi')
-  await t.notThrowsAsync(() => entry.setPassword(password))
-  t.is(await entry.getPassword(), password)
-  const [{ password: pass, account }] = await findCredentialsAsync(service)
-  t.is(pass, password)
-  t.is(account, 'napi')
+  const entry = new AsyncEntry(testService, testUser)
+  await t.notThrowsAsync(() => entry.setPassword(testPassword))
+  t.is(await entry.getPassword(), testPassword)
+  const [{ password: pass, account }] = await findCredentialsAsync(testService)
+  t.is(pass, testPassword)
+  t.is(account, testUser)
   await t.notThrowsAsync(() => entry.deletePassword())
 })
+
+let testTarget: string | undefined
+
+const platform = os.platform()
+switch (platform) {
+  // macOS uses target to choose between one of the following keychains: 'User', 'System', 'Common', 'Dynamic'. Default: 'User'
+  case 'darwin':
+    testTarget = 'User'
+    break
+  // Windows uses target as the only keyring identifier. Default: {service}.{user}
+  case 'win32':
+    testTarget = `keyring-node-test-target.${testService}.${testUser}`
+    break
+  // Linux uses target as the only keyring identifier. Default: keyring-rs:{user}@{service}
+  case 'linux':
+  case 'freebsd':
+    testTarget = `keyring-node-test-target:${testUser}@${testService}`
+    break
+  default:
+    console.info(`Unsupported OS to test [${platform}]`)
+}
+
+if (testTarget && !(process.env.CI && (platform === 'linux' || platform === 'freebsd'))) {
+  test('Entry.withTarget() should use valid target', (t) => {
+    const entry = Entry.withTarget(testTarget!, testService, testUser)
+    t.notThrows(() => entry.setPassword(testPassword))
+    t.is(entry.getPassword(), testPassword)
+    const [{ password: pass, account }] = findCredentials(testService, testTarget!)
+    t.is(pass, testPassword)
+    t.is(account, testUser)
+    t.notThrows(() => entry.deletePassword())
+  })
+
+  test('AsyncEntry.withTarget() should use valid target', async (t) => {
+    const entry = AsyncEntry.withTarget(testTarget!, testService, testUser)
+    await t.notThrowsAsync(() => entry.setPassword(testPassword))
+    t.is(await entry.getPassword(), testPassword)
+    const [{ password: pass, account }] = await findCredentialsAsync(testService, testTarget!)
+    t.is(pass, testPassword)
+    t.is(account, testUser)
+    await t.notThrowsAsync(() => entry.deletePassword())
+  })
+} else {
+  test.skip(`Skip testing Entry.withTarget() because of non-supported operating system: ${platform}`, (t) => {
+    t.fail()
+  })
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,9 +8,9 @@ export interface Credential {
   password: string
 }
 /** find credentials by service name */
-export function findCredentials(service: string): Array<Credential>
+export function findCredentials(service: string, target?: string | undefined | null): Array<Credential>
 /** find credentials by service name */
-export function findCredentialsAsync(service: string, signal?: AbortSignal | undefined | null): Promise<Array<Credential>>
+export function findCredentialsAsync(service: string, target?: string | undefined | null, signal?: AbortSignal | undefined | null): Promise<Array<Credential>>
 export class AsyncEntry {
   /**
    * Create an entry for the given service and username.
@@ -23,7 +23,7 @@ export class AsyncEntry {
    *
    * The default credential builder is used.
    */
-  static withTarget(service: string, username: string, target: string): AsyncEntry
+  static withTarget(target: string, service: string, username: string): AsyncEntry
   /**
    * Set the password for this entry.
    *
@@ -71,7 +71,7 @@ export class Entry {
    *
    * The default credential builder is used.
    */
-  static withTarget(service: string, username: string, target: string): Entry
+  static withTarget(target: string, service: string, username: string): Entry
   /**
    * Set the password for this entry.
    *

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "format:rs": "cargo fmt",
     "lint": "eslint . -c ./.eslintrc.yml",
     "prepublishOnly": "napi prepublish -t npm",
-    "test": "ava",
+    "test": "ava -s",
     "version": "napi version"
   },
   "devDependencies": {
@@ -60,6 +60,7 @@
     "@swc-node/register": "^1.6.6",
     "@swc/core": "^1.3.69",
     "@taplo/cli": "^0.5.2",
+    "@types/node": "^20.4.2",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "ava": "^5.3.1",

--- a/src/async_entry.rs
+++ b/src/async_entry.rs
@@ -24,10 +24,10 @@ impl AsyncEntry {
   /// Create an entry for the given target, service, and username.
   ///
   /// The default credential builder is used.
-  pub fn with_target(service: String, username: String, target: String) -> Result<Self> {
+  pub fn with_target(target: String, service: String, username: String) -> Result<Self> {
     Ok(Self {
       inner: Arc::new(
-        keyring::Entry::new_with_target(&service, &username, &target)
+        keyring::Entry::new_with_target(&target, &service, &username)
           .map_err(anyhow::Error::from)?,
       ),
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -154,6 +154,7 @@ __metadata:
     "@swc-node/register": ^1.6.6
     "@swc/core": ^1.3.69
     "@taplo/cli": ^0.5.2
+    "@types/node": ^20.4.2
     "@typescript-eslint/eslint-plugin": ^6.0.0
     "@typescript-eslint/parser": ^6.0.0
     ava: ^5.3.1
@@ -390,6 +391,13 @@ __metadata:
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
   checksum: e60b153664572116dfea673c5bda7778dbff150498f44f998e34b5886d8afc47f16799280e4b6e241c0472aef1bc36add771c569c68fc5125fc2ae519a3eb9ac
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^20.4.2":
+  version: 20.4.2
+  resolution: "@types/node@npm:20.4.2"
+  checksum: 99e544ea7560d51f01f95627fc40394c24a13da8f041121a0da13e4ef0a2aa332932eaf9a5e8d0e30d1c07106e96a183be392cbba62e8cf0bf6a085d5c0f4149
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Just a quick fix to the ordering of with_target arguments. The tests pass on MacOS. Not sure how they behave on other platforms. Might be beneficial to enable matrix tests for PRs.