### PR TITLE
Fall back to keyutils if secret-service not available in Linux

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,6 @@
 
 pub mod async_entry;
 pub mod entry;
+
+#[cfg(target_os = "linux")]
+mod linux_credential_builder;

--- a/src/linux_credential_builder.rs
+++ b/src/linux_credential_builder.rs
@@ -1,0 +1,50 @@
+use keyring::{
+  credential::{CredentialApi, CredentialBuilderApi},
+  keyutils::KeyutilsCredential,
+  secret_service::SsCredential,
+};
+
+use std::any::Any;
+use std::error::Error;
+
+/// A custom builder that falls back to keyutils if secret-service is not available.
+#[derive(Debug)]
+pub struct LinuxCredentialBuilder {
+  secret_service_missing: bool,
+}
+
+impl LinuxCredentialBuilder {
+  pub fn new() -> Result<Self, Box<dyn Error>> {
+    let ss = SsCredential::new_with_target(None, "test", "user")?;
+
+    let missing = match ss.map_matching_items(|_item| Ok(()), false) {
+      Err(keyring::Error::PlatformFailure(_x)) => true,
+      _ => false,
+    };
+
+    Ok(Self {
+      secret_service_missing: missing,
+    })
+  }
+}
+
+impl CredentialBuilderApi for LinuxCredentialBuilder {
+  fn build(
+    &self,
+    target: Option<&str>,
+    service: &str,
+    user: &str,
+  ) -> Result<Box<(dyn CredentialApi + Send + Sync + 'static)>, keyring::Error> {
+    if !self.secret_service_missing {
+      let cred = SsCredential::new_with_target(target, service, user)?;
+      return Ok(Box::new(cred));
+    }
+
+    let cred = KeyutilsCredential::new_with_target(target, service, user)?;
+    Ok(Box::new(cred))
+  }
+
+  fn as_any(&self) -> &dyn Any {
+    self
+  }
+}


### PR DESCRIPTION
When using this library from the context of WSL, where gnome-keyring etc is not available, it fails with a generic error along the lines of:

> Platform secure storage failure: zbus error: org.freedesktop.DBus.Error.ServiceUnknown: The name org.freedesktop.secrets was not provided by any .service files

Even after installing gnome-keyring, you still get an error like:

> Couldn't access platform secure storage: SS error: result not returned from SS API

[Reading the keyring-rs source](https://github.com/hwchen/keyring-rs/blob/master/src/secret_service.rs#L45-L70), it pretty much sounds like using Secret Service from a headless environment is not going to work. Since I'm using this library from the context of a cross-platform CLI, where some of my users are using WSL2, I need a way to use keyutils instead. So I've implemented a custom CredentialBuilder for Linux, that tries to use Secret Service but falls back to keyutils if Secret Service doesn't work.

I haven't implemented this same support for the `find_credentials` functions, as I can't really figure out what it's trying to do or why it isn't using keyring-rs. In my case I'm not using `find_credentials`, so having at least partial support for headless Linux is enough for me. The tests are passing in WSL2 if I remove the calls to `find_credentials` and only test `get_password` etc.

I'm definitely no rust developer, so let me know if something about this is wonky.