### PR TITLE
fix: preserve non-missing password read errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ export declare class AsyncEntry {
   /**
    * Retrieve the password saved for this entry.
    *
-   * Returns a [NoEntry](Error::NoEntry) error if there isn't one.
+   * Returns no password if there isn't one.
    *
    * Can return an [Ambiguous](Error::Ambiguous) error
    * if there is more than one platform credential
@@ -113,7 +113,7 @@ export declare class Entry {
   /**
    * Retrieve the password saved for this entry.
    *
-   * Returns a [NoEntry](Error::NoEntry) error if there isn't one.
+   * Returns no password if there isn't one.
    *
    * Can return an [Ambiguous](Error::Ambiguous) error
    * if there is more than one platform credential

--- a/src/async_entry.rs
+++ b/src/async_entry.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
+use crate::entry::into_optional_password;
 #[cfg(target_os = "linux")]
 use crate::linux_credential_builder::LinuxCredentialBuilder;
 
@@ -161,7 +162,7 @@ impl AsyncEntry {
   #[napi(ts_return_type = "Promise<string | undefined>")]
   /// Retrieve the password saved for this entry.
   ///
-  /// Returns a [NoEntry](Error::NoEntry) error if there isn't one.
+  /// Returns no password if there isn't one.
   ///
   /// Can return an [Ambiguous](Error::Ambiguous) error
   /// if there is more than one platform credential
@@ -250,7 +251,7 @@ impl Task for PasswordTask {
   type JsValue = Option<String>;
 
   fn compute(&mut self) -> Result<Self::Output> {
-    Ok(self.inner.get_password().ok())
+    into_optional_password(self.inner.get_password())
   }
 
   fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -4,6 +4,16 @@ use napi_derive::napi;
 #[cfg(target_os = "linux")]
 use crate::linux_credential_builder::LinuxCredentialBuilder;
 
+pub(crate) fn into_optional_password(
+  result: keyring_core::Result<String>,
+) -> Result<Option<String>> {
+  match result {
+    Ok(password) => Ok(Some(password)),
+    Err(keyring_core::Error::NoEntry) => Ok(None),
+    Err(error) => Err(anyhow::Error::from(error).into()),
+  }
+}
+
 #[napi]
 pub struct Entry {
   inner: keyring_core::Entry,
@@ -146,15 +156,15 @@ impl Entry {
   #[napi]
   /// Retrieve the password saved for this entry.
   ///
-  /// Returns a [NoEntry](Error::NoEntry) error if there isn't one.
+  /// Returns no password if there isn't one.
   ///
   /// Can return an [Ambiguous](Error::Ambiguous) error
   /// if there is more than one platform credential
   /// that matches this entry.  This can only happen
   /// on some platforms, and then only if a third-party
   /// application wrote the ambiguous credential.
-  pub fn get_password(&self) -> Option<String> {
-    self.inner.get_password().ok()
+  pub fn get_password(&self) -> Result<Option<String>> {
+    into_optional_password(self.inner.get_password())
   }
 
   #[napi]
@@ -197,6 +207,36 @@ impl Entry {
   /// Alias for `deleteCredential`
   pub fn delete_password(&self) -> bool {
     self.delete_credential()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::into_optional_password;
+
+  #[test]
+  fn returns_password_when_found() {
+    assert_eq!(
+      into_optional_password(Ok("password".to_string())).unwrap(),
+      Some("password".to_string())
+    );
+  }
+
+  #[test]
+  fn returns_none_when_password_is_missing() {
+    assert_eq!(
+      into_optional_password(Err(keyring_core::Error::NoEntry)).unwrap(),
+      None
+    );
+  }
+
+  #[test]
+  fn preserves_non_missing_errors() {
+    let result = into_optional_password(Err(keyring_core::Error::NoStorageAccess(Box::new(
+      std::io::Error::other("keychain is locked"),
+    ))));
+
+    assert!(result.is_err());
   }
 }
 


### PR DESCRIPTION
## Summary

- return no password only for `keyring_core::Error::NoEntry`
- propagate other password-read errors from sync and async entries
- add unit coverage for successful, missing, and failed reads

## Why

The wrapped libraries intentionally distinguish a missing credential from an
inaccessible or failing credential store. `keyring-core` returns
`Result<String>`, while the Apple backend maps `errSecItemNotFound` to
`NoEntry`, access failures to `NoStorageAccess`, and other Security.framework
failures to `PlatformFailure`.

Calling `.ok()` erases all those errors and makes every failure appear to
JavaScript as `null`/`undefined`. This change preserves the optional result for
`NoEntry` while allowing other failures to throw or reject.

This also matches node-keytar compatibility: missing credentials resolve as
`null`, while native failures reject.

GitHits helped find and verify this bug.[^investigation]

[^investigation]: **GitHits helped find and verify this bug.** Starting from a GitHits user report, GitHits' version-pinned package and source search traced the exact dependency chain from GitHits' resolved `@napi-rs/keyring@1.3.0` Darwin binaries ([lockfile](https://github.com/githits-com/githits-cli/blob/e7a604901c12bea415cb29c6a94a23b8ebb61ecb/bun.lock#L114-L118)) to `.ok()` at both N-API read boundaries ([sync](https://github.com/Brooooooklyn/keyring-node/blob/v1.3.0/src/entry.rs#L146-L158), [async](https://github.com/Brooooooklyn/keyring-node/blob/v1.3.0/src/async_entry.rs#L247-L258)). Following those calls into the exact wrapped crates showed that `keyring-core@1.0.0` preserves the full `Result<String>` contract ([source](https://github.com/open-source-cooperative/keyring-core/blob/eb41b5cd54694c1622d3c30c59f2e87368463151/src/lib.rs#L241-L264)) and the Apple backend preserves OS-status distinctions ([mapping](https://github.com/open-source-cooperative/apple-native-keyring-store/blob/f5077a207b0dada4d072226693229e5e6b416fd4/src/keychain.rs#L360-L373)), isolating the information loss to this wrapper.

## Validation

- 3 Rust unit tests passed
- 8 JavaScript integration tests passed
- debug and release native builds passed
- JavaScript lint, Rust formatting, and diff checks passed

